### PR TITLE
Full support for Wavefront data format

### DIFF
--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
+	"log"
 )
 
 type Wavefront struct {
@@ -113,7 +114,7 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 		for _, metric := range buildMetrics(m, w) {
 			messageLine := fmt.Sprintf("%s %s %v %s\n",	metric.Metric, metric.Value, metric.Timestamp, metric.Tags)
 			if w.Debug {
-				fmt.Print(messageLine)
+				log.Printf("DEBUG: output [wavefront] %s", messageLine)
 			}
 			_, err := connection.Write([]byte(messageLine))
 			if err != nil {
@@ -147,13 +148,13 @@ func buildTags(mTags map[string]string, w *Wavefront) []string {
 
 func buildMetrics(m telegraf.Metric, w *Wavefront) []*MetricLine {
 	if w.DebugAll {
-		fmt.Printf("Original name: %s\n", m.Name())
+		log.Printf("DEBUG: output [wavefront] original name: %s\n", m.Name())
 	}
 
 	ret := []*MetricLine{}
 	for fieldName, value := range m.Fields() {
 		if w.DebugAll {
-			fmt.Printf("Original field: %s\n", fieldName)
+			log.Printf("DEBUG: output [wavefront] original field: %s\n", fieldName)
 		}
 
 		var name string
@@ -179,7 +180,7 @@ func buildMetrics(m telegraf.Metric, w *Wavefront) []*MetricLine {
 		}
 		metricValue, buildError := buildValue(value, metric.Metric)
 		if buildError != nil {
-			fmt.Printf("Wavefront: %s\n", buildError.Error())
+			log.Printf("ERROR: output [wavefront] %s\n", buildError.Error())
 			continue
 		}
 		metric.Value = metricValue

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -46,18 +46,18 @@ func TestBuildTagsTelnet(t *testing.T) {
 // 		t.Skip("Skipping integration test in short mode")
 // 	}
 
-// 	o := &OpenTSDB{
+// 	w := &Wavefront{
 // 		Host:   testutil.GetLocalHost(),
-// 		Port:   4242,
+// 		Port:   2878,
 // 		Prefix: "prefix.test.",
 // 	}
 
-// 	// Verify that we can connect to the OpenTSDB instance
-// 	err := o.Connect()
+// 	// Verify that we can connect to the Wavefront instance
+// 	err := w.Connect()
 // 	require.NoError(t, err)
 
-// 	// Verify that we can successfully write data to OpenTSDB
-// 	err = o.Write(testutil.MockMetrics())
+// 	// Verify that we can successfully write data to Wavefront
+// 	err = w.Write(testutil.MockMetrics())
 // 	require.NoError(t, err)
 
 // 	// Verify postive and negative test cases of writing data
@@ -75,6 +75,6 @@ func TestBuildTagsTelnet(t *testing.T) {
 // 	metrics = append(metrics, testutil.TestMetric(float64(42.0),
 // 		"metric w/ specialchars"))
 
-// 	err = o.Write(metrics)
+// 	err = w.Write(metrics)
 // 	require.NoError(t, err)
 // }


### PR DESCRIPTION
Added a metric_separator config property which is used between the metric name and field name when outputting metrics.

Also added additional verbiage to error message (metric name) in buildValue
