### PR TITLE
Enabling vSAN Perf Collection

### DIFF
--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -46,6 +46,7 @@ type Endpoint struct {
 	initialized     bool
 	clientFactory   *ClientFactory
 	busy            sync.Mutex
+	apiVersion      float32 // Fetch the apiVersion string and save it as float.
 }
 
 type resourceKind struct {
@@ -85,6 +86,8 @@ type objectRef struct {
 	parentRef *types.ManagedObjectReference //Pointer because it must be nillable
 	guest     string
 	dcname    string
+	// placeholder for properties specific to this objectRef.
+	properties map[string]interface{}
 }
 
 func (e *Endpoint) getParent(obj *objectRef, res *resourceKind) (*objectRef, bool) {
@@ -367,7 +370,19 @@ func (e *Endpoint) discover(ctx context.Context) error {
 		return err
 	}
 
-	log.Printf("D! [inputs.vsphere]: Discover new objects for %s", e.URL.Host)
+	// get the vSphere API version
+	apiVersionStr := client.Client.ServiceContent.About.ApiVersion
+	apiVersion, err := strconv.ParseFloat(apiVersionStr, 32)
+
+	if err != nil {
+		log.Printf("I! Cannot determine API Version: %s. Error: %s", apiVersionStr, err)
+	} else {
+		// ParseFloat always returns float 64, but it's safe to convert to
+		// float32 as long as we pass in 32 as the `byteSize` arg to it.
+		e.apiVersion = float32(apiVersion)
+	}
+
+	log.Printf("D! [inputs.vsphere] Discover new objects for %s", e.URL.Host)
 	resourceKinds := make(map[string]resourceKind)
 	dcNameCache := make(map[string]string)
 
@@ -376,7 +391,7 @@ func (e *Endpoint) discover(ctx context.Context) error {
 	// Populate resource objects, and endpoint instance info.
 	newObjects := make(map[string]objectMap)
 	for k, res := range e.resourceKinds {
-		log.Printf("D! [inputs.vsphere] Discovering resources for %s", res.name)
+		log.Printf("D! [inputs.vsphere]  Discovering resources for %s", res.name)
 		// Need to do this for all resource types even if they are not enabled
 		if res.enabled || k != "vm" {
 			rf := ResourceFilter{
@@ -550,6 +565,7 @@ func getClusters(ctx context.Context, e *Endpoint, filter *ResourceFilter) (obje
 	}
 	cache := make(map[string]*types.ManagedObjectReference)
 	m := make(objectMap, len(resources))
+	var clusterProps map[string]interface{}
 	for _, r := range resources {
 		// We're not interested in the immediate parent (a folder), but the data center.
 		p, ok := cache[r.Parent.Value]
@@ -573,9 +589,24 @@ func getClusters(ctx context.Context, e *Endpoint, filter *ResourceFilter) (obje
 				p = &pp
 				cache[r.Parent.Value] = p
 			}
+
+			// For clusters, check if vSAN is enabled or not.
+			// NOTE: apiVersion of 5.5 is required for VsanConfigInfo object to exist
+			// in cluster config
+			if e.apiVersion > 5.5 {
+				cluster := object.NewClusterComputeResource(client.Client.Client, r.ExtensibleManagedObject.Reference())
+				clusterConfig, err := cluster.Configuration(ctx)
+
+				if err != nil {
+					log.Printf("D! Failed to get cluster config: %s. Skipping '%s' for vSAN collection", err, r.Name)
+				}
+
+				clusterProps = make(map[string]interface{})
+				clusterProps["vsanEnabled"] = *clusterConfig.VsanConfigInfo.Enabled
+			}
 		}
 		m[r.ExtensibleManagedObject.Reference().Value] = objectRef{
-			name: r.Name, ref: r.ExtensibleManagedObject.Reference(), parentRef: p}
+			name: r.Name, ref: r.ExtensibleManagedObject.Reference(), parentRef: p, properties: clusterProps}
 	}
 	return m, nil
 }
@@ -649,6 +680,31 @@ func (e *Endpoint) Close() {
 	e.clientFactory.Close()
 }
 
+func (e *Endpoint) collectVsan(ctx context.Context, res *resourceKind, wg *sync.WaitGroup, acc telegraf.Accumulator) {
+	// Start vSAN Collection for each vSAN enabled cluster
+	for _, obj := range res.objects {
+		client, err := e.clientFactory.GetClient(ctx)
+
+		if err != nil {
+			log.Printf("D! Failed to get client: %s", err)
+			continue
+		}
+
+		// bail out if vSphere API Version is < 5.5
+		if e.apiVersion < 5.5 {
+			log.Printf("I! Minimum API Version 5.5 required for vSAN. Found: %.1f. Skipping Cluster: %s", e.apiVersion, obj.ref.String())
+			continue
+		}
+
+		val, ok := obj.properties["vsanEnabled"].(bool)
+		if ok && val {
+			wg.Add(1)
+			log.Printf("D! [inputs.vsphere][vSAN] vSAN Configured for cluster: %s", obj.name)
+			go CollectVsan(ctx, client.Client.Client, obj, wg, e.URL.Host, acc)
+		}
+	}
+}
+
 // Collect runs a round of data collections as specified in the configuration.
 func (e *Endpoint) Collect(ctx context.Context, acc telegraf.Accumulator) error {
 
@@ -684,6 +740,10 @@ func (e *Endpoint) Collect(ctx context.Context, acc telegraf.Accumulator) error 
 					acc.AddError(err)
 				}
 			}(k)
+
+			if res.name == "cluster" && e.Parent.VsanCollectionEnabled {
+				e.collectVsan(ctx, res, &wg, acc)
+			}
 		}
 	}
 	wg.Wait()

--- a/plugins/inputs/vsphere/vsan.go
+++ b/plugins/inputs/vsphere/vsan.go
@@ -1,0 +1,271 @@
+package vsphere
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/soap"
+
+	"github.com/influxdata/telegraf"
+	vsanMethods "github.com/influxdata/telegraf/plugins/inputs/vsphere/vsan/methods"
+	vsanTypes "github.com/influxdata/telegraf/plugins/inputs/vsphere/vsan/types"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	vsanNamespace   = "vsan"
+	vsanPath        = "/vsanHealth"
+	timeFormat      = "Mon, 02 Jan 2006 15:04:05 MST"
+	vsanMetricsName = "vsphere_cluster_vsan"
+)
+
+var (
+	vsanPerformanceManagerInstance = types.ManagedObjectReference{
+		Type:  "VsanPerformanceManager",
+		Value: "vsan-performance-manager",
+	}
+
+	vsanPerfEntityRefIds = []string{
+		"host-domclient",
+		"host-domcompmgr",
+		"cache-disk",
+		"capacity-disk",
+		"vsan-vnic-net",
+		"vsan-pnic-net",
+		"lsom-world-cpu",
+		"dom-world-cpu",
+	}
+)
+
+/*
+All this cryptic code in formatAndSendVsanMetric is to parse the vsanTypes.VsanPerfEntityMetricCSV type, which has the structure:
+{
+  "@type": "vim.cluster.VsanPerfEntityMetricCSV",
+  "entityRefId": "cluster-domclient:5270dc4d-3594-cc26-b33d-f6be33ddb353",
+  "sampleInfo": "2017-06-14 23:10:00,2017-06-14 23:15:00,2017-06-14 23:20:00,2017-06-14 23:25:00,2017-06-14 23:30:00,2017-06-14 23:35:00,2017-06-14 23:40:00,2017-06-14 23:45:00,2017-06-14 23:50:00,2017-06-14 23:55:00,2017-06-15 00:00:00,2017-06-15 00:05:00,2017-06-15 00:10:00",
+  "value": [
+    {
+      "@type": "vim.cluster.VsanPerfMetricSeriesCSV",
+      "metricId": {
+        "@type": "vim.cluster.VsanPerfMetricId",
+        "description": null,
+        "group": null,
+        "label": "iopsRead",
+        "metricsCollectInterval": 300,
+        "name": null,
+        "rollupType": null,
+        "statsType": null
+      },
+      "threshold": null,
+      "values": "1,1,1,1,1,1,1,1,1,1,1,1,1"
+    },
+		...
+		...
+	]
+}
+*/
+func formatAndSendVsanMetric(entity vsanTypes.VsanPerfEntityMetricCSV, defaultTags map[string]string, cmmds map[string]vsanTypes.CmmdsEntity, acc telegraf.Accumulator) {
+	vals := strings.Split(entity.EntityRefId, ":")
+	entityName := vals[0]
+	uuid := vals[1]
+	tags := make(map[string]string)
+
+	for k, v := range defaultTags {
+		tags[k] = v
+	}
+
+	// Add some additional tags based on CMMDS data
+	if strings.Contains(entityName, "-disk") {
+		if e, ok := cmmds[uuid]; ok {
+			if host, ok := cmmds[e.Owner]; ok {
+				if c, ok := host.Content.(map[string]interface{}); ok {
+					tags["hostname"] = c["hostname"].(string)
+				}
+			}
+			if c, ok := e.Content.(map[string]interface{}); ok {
+				tags["deviceName"] = c["devName"].(string)
+				if int(c["isSsd"].(float64)) == 0 {
+					tags["ssdUuid"] = c["ssdUuid"].(string)
+				}
+			}
+		}
+	} else if strings.Contains(entityName, "host-") {
+		if e, ok := cmmds[uuid]; ok {
+			if c, ok := e.Content.(map[string]interface{}); ok {
+				tags["hostname"] = c["hostname"].(string)
+			}
+		}
+	} else if strings.Contains(entityName, "vnic-net") {
+		nicInfo := strings.Split(uuid, "|")
+		tags["stackName"] = nicInfo[1]
+		tags["vnic"] = nicInfo[2]
+		if e, ok := cmmds[nicInfo[0]]; ok {
+			if c, ok := e.Content.(map[string]interface{}); ok {
+				tags["hostname"] = c["hostname"].(string)
+			}
+		}
+	} else if strings.Contains(entityName, "pnic-net") {
+		nicInfo := strings.Split(uuid, "|")
+		tags["pnic"] = nicInfo[1]
+		if e, ok := cmmds[nicInfo[0]]; ok {
+			if c, ok := e.Content.(map[string]interface{}); ok {
+				tags["hostname"] = c["hostname"].(string)
+			}
+		}
+	} else if strings.Contains(entityName, "world-cpu") {
+		cpuInfo := strings.Split(uuid, "|")
+		tags["worldName"] = cpuInfo[1]
+		tags["worldId"] = cpuInfo[2]
+		if e, ok := cmmds[cpuInfo[0]]; ok {
+			if c, ok := e.Content.(map[string]interface{}); ok {
+				tags["hostname"] = c["hostname"].(string)
+			}
+		}
+	} else {
+		tags["uuid"] = uuid
+	}
+
+	var timeStamps []string
+	for _, t := range strings.Split(entity.SampleInfo, ",") {
+		tsParts := strings.Split(t, " ")
+		timeStamps = append(timeStamps, fmt.Sprintf("%sT%sZ", tsParts[0], tsParts[1]))
+	}
+	for _, counter := range entity.Value {
+		metricLabel := counter.MetricId.Label
+		for i, values := range strings.Split(counter.Values, ",") {
+			ts, ok := time.Parse(time.RFC3339, timeStamps[i])
+			if ok != nil {
+				// can't do much if we couldn't parse time
+				log.Printf("E! [inputs.vsphere][vSAN]Failed to parse a timestamp: %s", timeStamps[i])
+				continue
+			}
+			fields := make(map[string]interface{})
+			field := fmt.Sprintf("%s_%s", entityName, metricLabel)
+			if v, err := strconv.ParseFloat(values, 32); err == nil {
+				fields[field] = v
+			}
+			acc.AddFields(vsanMetricsName, fields, tags, ts)
+		}
+	}
+}
+
+func getAllVsanMetrics(ctx context.Context, vsanClient *soap.Client, cluster *object.ClusterComputeResource, tags map[string]string, cmmds map[string]vsanTypes.CmmdsEntity, acc telegraf.Accumulator) {
+	endTime := time.Now()
+	startTime := endTime.Add(time.Duration(-5) * time.Minute)
+	log.Printf("D! [inputs.vsphere][vSAN]Querying data between: %s -> %s", startTime.Format(timeFormat), endTime.Format(timeFormat))
+	for _, entityRefID := range vsanPerfEntityRefIds {
+		var querySpecs []vsanTypes.VsanPerfQuerySpec
+
+		spec := vsanTypes.VsanPerfQuerySpec{
+			EntityRefId: fmt.Sprintf("%s:*", entityRefID),
+			StartTime:   &startTime,
+			EndTime:     &endTime,
+		}
+		querySpecs = append(querySpecs, spec)
+
+		vsanPerfQueryPerf := vsanTypes.VsanPerfQueryPerf{
+			This:       vsanPerformanceManagerInstance,
+			QuerySpecs: querySpecs,
+			Cluster:    cluster.Reference(),
+		}
+		res, err := vsanMethods.VsanPerfQueryPerf(ctx, vsanClient, &vsanPerfQueryPerf)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, ret := range res.Returnval {
+			log.Printf("D! [inputs.vsphere][vSAN]\tSuccessfully Fetched data for Entity ==> %s:%d\n", ret.EntityRefId, len(ret.Value))
+			formatAndSendVsanMetric(ret, tags, cmmds, acc)
+		}
+	}
+}
+
+func getVsanTags(cluster objectRef, vcenter string) map[string]string {
+	tags := make(map[string]string)
+	tags["vcenter"] = vcenter
+	tags["dcname"] = cluster.dcname
+	tags["clustername"] = cluster.name
+	tags["moid"] = cluster.ref.Value
+	tags["source"] = cluster.name
+	return tags
+}
+
+func getClusterCmmdsData(ctx context.Context, client *vim25.Client, cluster *object.ClusterComputeResource) (map[string]vsanTypes.CmmdsEntity, error) {
+	cmmds := make(map[string]vsanTypes.CmmdsEntity)
+	hosts, err := cluster.Hosts(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("no hosts found")
+	}
+
+	// TODO: Should we check if the host returned is connected or not!?
+	host := hosts[0]
+	vis, err := host.ConfigManager().VsanInternalSystem(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queries := make([]types.HostVsanInternalSystemCmmdsQuery, 2)
+	hostnameCmmdsQuery := types.HostVsanInternalSystemCmmdsQuery{
+		Type: "HOSTNAME",
+	}
+
+	diskCmmdsQuery := types.HostVsanInternalSystemCmmdsQuery{
+		Type: "DISK",
+	}
+
+	queries = append(queries, hostnameCmmdsQuery)
+	queries = append(queries, diskCmmdsQuery)
+
+	cmmdsQuery := types.QueryCmmds{
+		This:    vis.Reference(),
+		Queries: queries,
+	}
+
+	rawCmmds, err := methods.QueryCmmds(ctx, client.RoundTripper, &cmmdsQuery)
+	if err != nil {
+		return nil, err
+	}
+	var clusterCmmds vsanTypes.Cmmds
+
+	json.Unmarshal([]byte(rawCmmds.Returnval), &clusterCmmds)
+	for _, entity := range clusterCmmds.Res {
+		uuid := entity.UUID
+		cmmds[uuid] = entity
+	}
+	return cmmds, nil
+}
+
+// CollectVsan invokes the vSAN Performance Manager on the ClusterComputeResource from the input.
+func CollectVsan(ctx context.Context, client *vim25.Client, clusterObj objectRef, wg *sync.WaitGroup, vcenter string, acc telegraf.Accumulator) {
+	defer wg.Done()
+	cluster := object.NewClusterComputeResource(client, clusterObj.ref)
+	if clusterName, err := cluster.ObjectName(ctx); err != nil {
+		log.Printf("D! [inputs.vsphere][vSAN] Starting vSAN Collection for %s", clusterName)
+	}
+
+	tags := getVsanTags(clusterObj, vcenter)
+	log.Printf("D! [inputs.vsphere][vSAN] Tags for vSAN: %s", tags)
+
+	cmmds, err := getClusterCmmdsData(ctx, client, cluster)
+	if err != nil {
+		log.Printf("I! [inputs.vsphere][vSAN] Failed to get CMMDS Data. Cannot resolve UUIDs.")
+	}
+
+	// vSAN Client
+	vsanClient := client.NewServiceClient(vsanPath, vsanNamespace)
+	getAllVsanMetrics(ctx, vsanClient, cluster, tags, cmmds, acc)
+}

--- a/plugins/inputs/vsphere/vsan/methods/methods.go
+++ b/plugins/inputs/vsphere/vsan/methods/methods.go
@@ -1,0 +1,19 @@
+package methods
+
+import (
+	"context"
+	"github.com/influxdata/telegraf/plugins/inputs/vsphere/vsan/types"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+func VsanPerfQueryPerf(ctx context.Context, r soap.RoundTripper, req *types.VsanPerfQueryPerf) (*types.VsanPerfQueryPerfResponse, error) {
+	var reqBody, resBody types.VsanPerfQueryPerfBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}

--- a/plugins/inputs/vsphere/vsan/mo/mo.go
+++ b/plugins/inputs/vsphere/vsan/mo/mo.go
@@ -1,0 +1,22 @@
+package mo
+
+import (
+	"github.com/vmware/govmomi/vim25/types"
+	"reflect"
+)
+
+type PerformanceManager struct {
+	Self types.ManagedObjectReference
+
+	Description        types.PerformanceDescription `mo:"description"`
+	HistoricalInterval []types.PerfInterval         `mo:"historicalInterval"`
+	PerfCounter        []types.PerfCounterInfo      `mo:"perfCounter"`
+}
+
+func (m PerformanceManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["PerformanceManager"] = reflect.TypeOf((*PerformanceManager)(nil)).Elem()
+}

--- a/plugins/inputs/vsphere/vsan/mo/mo.go
+++ b/plugins/inputs/vsphere/vsan/mo/mo.go
@@ -18,5 +18,5 @@ func (m PerformanceManager) Reference() types.ManagedObjectReference {
 }
 
 func init() {
-	t["PerformanceManager"] = reflect.TypeOf((*PerformanceManager)(nil)).Elem()
+	 types.Add("PerformanceManager", reflect.TypeOf((*PerformanceManager)(nil)).Elem())
 }

--- a/plugins/inputs/vsphere/vsan/types/cmmds_types.go
+++ b/plugins/inputs/vsphere/vsan/types/cmmds_types.go
@@ -1,0 +1,12 @@
+package types
+
+type CmmdsEntity struct {
+	UUID    string      `json:"uuid"`
+	Owner   string      `json:"owner"`
+	Type    string      `json:"type"`
+	Content interface{} `json:"content"`
+}
+
+type Cmmds struct {
+	Res []CmmdsEntity `json:"result"`
+}

--- a/plugins/inputs/vsphere/vsan/types/registry.go
+++ b/plugins/inputs/vsphere/vsan/types/registry.go
@@ -1,0 +1,11 @@
+package types
+
+import (
+	"reflect"
+)
+
+var t = map[string]reflect.Type{}
+
+func Add(name string, kind reflect.Type) {
+	t[name] = kind
+}

--- a/plugins/inputs/vsphere/vsan/types/types.go
+++ b/plugins/inputs/vsphere/vsan/types/types.go
@@ -1,0 +1,123 @@
+package types
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// PerfMetricId defines
+type PerfMetricId struct {
+	CounterId int32  `xml:"counterId"`
+	Instance  string `xml:"instance"`
+}
+
+func init() {
+	t["PerfMetricId"] = reflect.TypeOf((*PerfMetricId)(nil)).Elem()
+}
+
+type VsanPerfQuerySpec struct {
+	EntityRefId string     `xml:"entityRefId"`
+	StartTime   *time.Time `xml:"startTime"`
+	EndTime     *time.Time `xml:"endTime"`
+	Group       string     `xml:"group,omitempty"`
+	Labels      []string   `xml:"labels,omitempty"`
+	Interval    int32      `xml:"interval,omitempty"`
+}
+
+func init() {
+	t["VsanPerfQuerySpec"] = reflect.TypeOf((*VsanPerfQuerySpec)(nil)).Elem()
+}
+
+type PerfQuerySpec struct {
+	Entity     types.ManagedObjectReference `xml:"entity"`
+	StartTime  *time.Time                   `xml:"startTime"`
+	EndTime    *time.Time                   `xml:"endTime"`
+	MaxSample  int32                        `xml:"maxSample,omitempty"`
+	MetricId   []PerfMetricId               `xml:"metricId,omitempty"`
+	IntervalId int32                        `xml:"intervalId,omitempty"`
+	Format     string                       `xml:"format,omitempty"`
+}
+
+func init() {
+	t["PerfQuerySpec"] = reflect.TypeOf((*PerfQuerySpec)(nil)).Elem()
+}
+
+type VsanPerfQueryPerf VsanPerfQueryPerfRequestType
+
+func init() {
+	t["VsanPerfQueryPerf"] = reflect.TypeOf((*VsanPerfQueryPerf)(nil)).Elem()
+}
+
+type VsanPerfQueryPerfRequestType struct {
+	This       types.ManagedObjectReference `xml:"_this"`
+	QuerySpecs []VsanPerfQuerySpec          `xml:"querySpecs"`
+	Cluster    types.ManagedObjectReference `xml:"cluster,omitempty"`
+}
+
+func init() {
+	t["VsanPerfQueryPerfRequestType"] = reflect.TypeOf((*VsanPerfQueryPerfRequestType)(nil)).Elem()
+}
+
+type VsanPerfMetricId struct {
+	Label                  string `xml:"label"`
+	Group                  string `xml:"group,omitempty"`
+	RollupType             string `xml:"rollupType,omitempty"`
+	StatsType              string `xml:"statsType,omitempty"`
+	Name                   string `xml:"name,omitempty"`
+	Description            string `xml:"description,omitempty"`
+	MetricsCollectInterval int32  `xml:"metricsCollectInterval,omitempty"`
+}
+
+func init() {
+	t["VsanPerfMetricId"] = reflect.TypeOf((*VsanPerfMetricId)(nil)).Elem()
+}
+
+type VsanPerfThreshold struct {
+	Direction string `xml:"direction"`
+	Yellow    string `xml:"yellow,omitempty"`
+	Red       string `xml:"red,omitempty"`
+}
+
+func init() {
+	t["VsanPerfThreshold"] = reflect.TypeOf((*VsanPerfThreshold)(nil)).Elem()
+}
+
+type VsanPerfMetricSeriesCSV struct {
+	MetricId  VsanPerfMetricId   `xml:"metricId"`
+	Threshold *VsanPerfThreshold `xml:"threshold,omitempty"`
+	Values    string             `xml:"values,omitempty"`
+}
+
+func init() {
+	t["VsanPerfMetricSeriesCSV"] = reflect.TypeOf((*VsanPerfMetricSeriesCSV)(nil)).Elem()
+}
+
+type VsanPerfEntityMetricCSV struct {
+	EntityRefId string                    `xml:"entityRefId"`
+	SampleInfo  string                    `xml:"sampleInfo,omitempty"`
+	Value       []VsanPerfMetricSeriesCSV `xml:"value,omitempty"`
+}
+
+func init() {
+	t["VsanPerfEntityMetricCSV"] = reflect.TypeOf((*VsanPerfEntityMetricCSV)(nil)).Elem()
+}
+
+type VsanPerfQueryPerfResponse struct {
+	Returnval []VsanPerfEntityMetricCSV `xml:"returnval"`
+}
+
+type VsanPerfQueryPerfBody struct {
+	Req    *VsanPerfQueryPerf         `xml:"urn:vsan VsanPerfQueryPerf,omitempty"`
+	Res    *VsanPerfQueryPerfResponse `xml:"urn:vsan VsanPerfQueryPerfResponse,omitempty"`
+	Fault_ *soap.Fault                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+// VsanPerfQueryPerfBody must implement HasFault interface
+func (b *VsanPerfQueryPerfBody) Fault() *soap.Fault { return b.Fault_ }
+
+func init() {
+	t["VsanPerfQueryPerfBody"] = reflect.TypeOf((*VsanPerfQueryPerfBody)(nil)).Elem()
+}

--- a/plugins/inputs/vsphere/vsphere.go
+++ b/plugins/inputs/vsphere/vsphere.go
@@ -54,6 +54,9 @@ type VSphere struct {
 
 	// Mix in the TLS/SSL goodness from core
 	tls.ClientConfig
+
+	// flag governing vSAN Collection
+	VsanCollectionEnabled bool
 }
 
 var sampleConfig = `
@@ -205,6 +208,9 @@ var sampleConfig = `
   # ssl_key = "/path/to/keyfile"
   ## Use SSL but skip chain & host verification
   # insecure_skip_verify = false
+  #
+  ## Also collect vSAN Metrics on vSAN enabled clusters
+  # VsanCollectionEnabled = false
 `
 
 // SampleConfig returns a set of default configuration to be used as a boilerplate when setting up
@@ -320,6 +326,7 @@ func init() {
 			ForceDiscoverOnInit:     false,
 			ObjectDiscoveryInterval: internal.Duration{Duration: time.Second * 300},
 			Timeout:                 internal.Duration{Duration: time.Second * 60},
+			VsanCollectionEnabled:   false,
 		}
 	})
 }


### PR DESCRIPTION
### Design
vSAN Collection is a part of the cluster monitoring code. This is because:
* vSAN Data is also historical data
* vSAN is inherently a cluster configuration.

On enabling this, every time a cluster collection is run, a vSAN collection is also invoked. Data is fetched using the vSAN Performance Manager APIs. Data is collected in parallel for each cluster which has vSAN enabled in vSphere.

### Requirements
* vCenter with at-least one vSAN enabled cluster
* Min API version of 5.5
* Configuring the vSphere plugin with a user who has at-least `System.Read` level auth on clusters

### Changes made to vSphere Plugin
* Query and save the API version for each vCenter configured
* Add a field to `objectRef` type. This is a placeholder for any special configuration that we need to keep track of.
* Code to fetch and save each of these.

### vSAN Data
The collection is configured to collect
* host-domclient
* host-domcompmgr
* cache-disk
* capacity-disk
* vsan-vnic-net
* vsan-pnic-net
* lsom-world-cpu
* dom-world-cpu

In the future, this could possibly be made configurable. There are other advanced metrics that we can omit for basic monitoring of vSAN. Also, the other reason the list is smaller is because these are common across versions of vSAN. There are more advanced metrics added to newer versions.

### Configuration
The best way to configure the vSAN Collection to have a separate instance for it.

<details>
<summary>Example Configuration</summary>
<pre><code>
[[inputs.vsphere]]
  interval = "300s" ## Let this run once every 5 mins
  vcenters = [ "https://VC/sdk" ]
  username = "user@vsphere.local"
  password = "pass"
  vm_metric_exclude = ["*"] ## Nothing is excluded by default
  host_metric_exclude = ["*"] ## Nothing excluded by default
  cluster_metric_include = [] ## if omitted or empty, all metrics are collected
  datastore_metric_exclude = ["*"] ## Nothing excluded by defaultected
  datacenter_metric_exclude = [ "*" ] ## Datacenters are not collected by default.
  VsanCollectionEnabled = true
</code></pre>
</details>